### PR TITLE
Add settings modal to chat UI for workshop filtering

### DIFF
--- a/app.R
+++ b/app.R
@@ -90,8 +90,7 @@ server <- function(input, output, session) {
       modalDialog(
         title = "Settings",
         bslib::input_switch("switch_workshops", "Ignore all workshops", value = isTRUE(input$switch_workshops)),
-        easyClose = TRUE,
-        footer = NULL
+        easyClose = TRUE
       )
     )
   })

--- a/app.R
+++ b/app.R
@@ -60,16 +60,15 @@ ui <- bslib::page_sidebar(
       p("Welcome to a chat bot for posit::conf(2025)! Start by typing in a question."),
       p("This chat interface allows you to ask questions about the sessions at posit::conf(2025)."),
       p("The chat is powered by ellmer using an OpenAI model and retrieves relevant information from a ragnar knowledge store."),
+      tags$div(
+        style = "position: absolute; top: 1rem; right: 1rem; z-index: 1000;",
+        actionButton("open_settings", label = NULL, icon = shiny::icon("gear"), class = "btn btn-default")
+      ),
       class = "text-center"
   ),
   shinychat::chat_ui(
     "chat",
-    messages = list(
-      welcome_message,
-      bslib::card(
-        "Settings:",
-        bslib::input_switch("switch_workshops", "Ignore all workshops", value = FALSE))
-    )
+    messages = welcome_message
   )
 )
 
@@ -86,6 +85,17 @@ server <- function(input, output, session) {
     shinychat::chat_append("chat", stream)
   })
 
+  observeEvent(input$open_settings, {
+    showModal(
+      modalDialog(
+        title = "Settings",
+        bslib::input_switch("switch_workshops", "Ignore all workshops", value = isTRUE(input$switch_workshops)),
+        easyClose = TRUE,
+        footer = NULL
+      )
+    )
+  })
+
   observeEvent(input$switch_workshops, {
     chat$set_system_prompt(
       ellmer::interpolate_file(
@@ -98,3 +108,4 @@ server <- function(input, output, session) {
 }
 
 shinyApp(ui, server)
+


### PR DESCRIPTION
The primary changes include adding a settings button to the UI and implementing a modal dialog to manage settings.

### UI Enhancements:
* Added a settings button (`actionButton`) to the top-right corner of the chat interface for easy access to settings. (`app.R`, [app.RR63-R71](diffhunk://#diff-ee89f65a0b4e0dccabce1672d6d689b4e2b6ca51ea1e746bdda1eca94aaa6e0fR63-R71))

### Server Logic Updates:
* Implemented an `observeEvent` to display a modal dialog when the settings button is clicked. The modal includes a toggle switch (`input_switch`) for ignoring workshops. (`app.R`, [app.RR88-R98](diffhunk://#diff-ee89f65a0b4e0dccabce1672d6d689b4e2b6ca51ea1e746bdda1eca94aaa6e0fR88-R98))